### PR TITLE
feat(Configuration): add asset bundle custom configuration

### DIFF
--- a/AssetBundleManager/AssetBundleManager.cs
+++ b/AssetBundleManager/AssetBundleManager.cs
@@ -175,7 +175,7 @@ namespace AssetBundles
         /// </summary>
         public static void SetSourceAssetBundleDirectory(string relativePath)
         {
-            BaseDownloadingURL = GetStreamingAssetsPath() + relativePath;
+            BaseDownloadingURL = Utility.GetAssetBundlesOutputUrl() + relativePath;
         }
 
         /// <summary>
@@ -598,6 +598,18 @@ namespace AssetBundles
             if (SimulateAssetBundleInEditor)
             {
                 string[] assetPaths = AssetDatabase.GetAssetPathsFromAssetBundleAndAssetName(assetBundleName, assetName);
+                if (assetPaths.Length == 0)
+                {
+                    foreach (var variant in m_ActiveVariants)
+                    {
+                        string variantAssetBundleName = assetBundleName + '.' + variant;
+                        assetPaths = AssetDatabase.GetAssetPathsFromAssetBundleAndAssetName(variantAssetBundleName, assetName);
+                        if (assetPaths.Length > 0)
+                        {
+                            break;
+                        }
+                    }
+                }
                 if (assetPaths.Length == 0)
                 {
                     Log(LogType.Error, "There is no asset with name \"" + assetName + "\" in " + assetBundleName);

--- a/AssetBundleManager/AssetBundleSettings.cs
+++ b/AssetBundleManager/AssetBundleSettings.cs
@@ -1,0 +1,104 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace AssetBundles
+{
+    ////[ExecuteInEditMode]
+    public class AssetBundleSettings : MonoBehaviour
+    {
+        public enum BasePathType
+        {
+            /// <summary>
+            /// Use this for complete URL
+            /// </summary>
+            None,
+            StreamingAssets,
+            Data,
+            PersistentData,
+            Executable,
+        }
+
+        [Tooltip("If this is true then the instance of the AssetBundleSettings won't be destroyed on every scene load.")]
+        public bool persistOnLoad = false;
+
+        [Tooltip("Base path type (actual path determined at run time).\nSelect None for complete URL")]
+        [SerializeField]
+        private BasePathType assetBundlesBasePath = BasePathType.StreamingAssets;
+
+        [Tooltip("Asset bundles URL or path (relative to the asset bundles base path)")]
+        [SerializeField]
+        private string assetBundlesPath = string.Empty;
+
+        /// <summary>
+        /// The singleton instance to access the AssetBundleSettings.
+        /// </summary>
+        private static AssetBundleSettings instance = null;
+
+        public static BasePathType AssetBundlesBasePath
+        {
+            get
+            {
+                GetInstance();
+                if (instance == null)
+                {
+                    //Debug.Log("AssetBundleSettings component not available, using default settings.");
+                    return BasePathType.StreamingAssets;
+                }
+
+                return instance.assetBundlesBasePath;
+            }
+        }
+
+        public static string AssetBundlesPath
+        {
+            get
+            {
+                GetInstance();
+                if(instance == null)
+                {
+                    return string.Empty;
+                }
+
+                return instance.assetBundlesPath;
+            }
+        }
+
+        public static AssetBundleSettings GetInstance()
+        {
+            if(instance == null)
+            {
+                instance = FindObjectOfType<AssetBundleSettings>();
+                if(instance != null)
+                {
+                    instance.SetInstance();
+                }
+            }
+            return instance;
+        }
+
+        protected virtual void Awake()
+        {
+            SetInstance();
+        }
+
+        private void SetInstance()
+        {
+            if (instance == null)
+            {
+                instance = this;
+                Debug.Log("AssetBundleSettings instance created");
+            }
+            else if (instance != this)
+            {
+                Destroy(gameObject);
+                return;
+            }
+
+            if (persistOnLoad)
+            {
+                DontDestroyOnLoad(gameObject);
+            }
+        }
+    }
+}

--- a/AssetBundleManager/AssetBundleSettings.cs.meta
+++ b/AssetBundleManager/AssetBundleSettings.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: fa74ff69c3b1a5145a3a30bff4217dff
+timeCreated: 1485415633
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/AssetBundleManager/Editor/BuildScript.cs
+++ b/AssetBundleManager/Editor/BuildScript.cs
@@ -16,10 +16,12 @@ namespace AssetBundles
         static public string CreateAssetBundleDirectory()
         {
             // Choose the output path according to the build target.
-            //string outputPath = Path.Combine(Utility.AssetBundlesOutputPath, Utility.GetPlatformName());
-            string outputPath = Path.Combine(Application.streamingAssetsPath, Utility.GetPlatformName());
+            string outputPath = Path.Combine(Utility.GetAssetBundlesOutputPath(), Utility.GetPlatformName());
             if (!Directory.Exists(outputPath))
+            {
+                Debug.Log("Creating directory " + outputPath);
                 Directory.CreateDirectory(outputPath);
+            }
 
             return outputPath;
         }
@@ -160,7 +162,7 @@ namespace AssetBundles
 
             // Build and copy AssetBundles.
             BuildScript.BuildAssetBundles();
-            //BuildScript.CopyAssetBundlesTo(Path.Combine(Application.streamingAssetsPath, Utility.AssetBundlesOutputPath));
+            //BuildScript.CopyAssetBundlesTo(Path.Combine(Utility.GetAssetBundlesOutputPath(), Utility.AssetBundlesOutputPath));
             AssetDatabase.Refresh();
 
 #if UNITY_5_4_OR_NEWER || UNITY_5_3 || UNITY_5_2 || UNITY_5_1 || UNITY_5_0
@@ -190,8 +192,10 @@ namespace AssetBundles
                 case BuildTarget.StandaloneOSXIntel64:
                 case BuildTarget.StandaloneOSXUniversal:
                     return "/Alpenhorn.app";
+#if !UNITY_5_4_OR_NEWER
                 case BuildTarget.WebPlayer:
                 case BuildTarget.WebPlayerStreamed:
+#endif
                 case BuildTarget.WebGL:
                 case BuildTarget.iOS:
                     return "";
@@ -205,13 +209,13 @@ namespace AssetBundles
         static void CopyAssetBundlesTo(string outputPath)
         {
             // Clear streaming assets folder.
-            FileUtil.DeleteFileOrDirectory(Application.streamingAssetsPath);
+            FileUtil.DeleteFileOrDirectory(Utility.GetAssetBundlesOutputPath());
             Directory.CreateDirectory(outputPath);
 
             string outputFolder = Utility.GetPlatformName();
 
             // Setup the source folder for assetbundles.
-            var source = Path.Combine(Path.Combine(System.Environment.CurrentDirectory, Application.streamingAssetsPath), outputFolder);
+            var source = Path.Combine(Path.Combine(System.Environment.CurrentDirectory, Utility.GetAssetBundlesBasePath()), outputFolder);
             if (!Directory.Exists(source))
                 Debug.Log("No assetBundle output folder, try to build the assetBundles first.");
 
@@ -237,8 +241,16 @@ namespace AssetBundles
 
         static string GetAssetBundleManifestFilePath()
         {
-            var relativeAssetBundlesOutputPathForPlatform = Path.Combine(Application.streamingAssetsPath, Utility.GetPlatformName());
+            var relativeAssetBundlesOutputPathForPlatform = Path.Combine(Utility.GetAssetBundlesOutputPath(), Utility.GetPlatformName());
             return Path.Combine(relativeAssetBundlesOutputPathForPlatform,  Utility.GetPlatformName()) + ".manifest";
         }
+
+        ////public static void SelectAssetBundleOutputPath()
+        ////{
+        ////    var outputPath = EditorUtility.SaveFolderPanel("Choose Location of asset bundles", "", "");
+        ////    if (outputPath.Length == 0)
+        ////        return;
+        ////    ////Utility.basePathType = 
+        ////}
     }
 }

--- a/AssetBundleManager/Utility.cs
+++ b/AssetBundleManager/Utility.cs
@@ -1,3 +1,5 @@
+using System;
+using System.IO;
 using UnityEngine;
 #if UNITY_EDITOR
 using UnityEditor;
@@ -10,6 +12,84 @@ namespace AssetBundles
         // Should figure out a way to make this a NON const string.  that way I can impliment the commeneted out line below.
         //public const string AssetBundlesOutputPath = "Assets/StreamingAssets/";
         //public const string AssetBundlesOutputPath = "file://" + Application.streamingAssetsPath + "/";
+        public enum BasePathType
+        {
+            Streaming=0,
+            Data=1,
+            PersistentData=1,
+            Executable=2,
+        }
+
+        public static string GetAssetBundlesBasePath()
+        {
+#if UNITY_EDITOR
+                //EditorPrefs.DeleteKey("AssetBundlesPathType");
+            //if (EditorPrefs.HasKey("AssetBundlesPathType"))
+            //{
+            //    basePathType = (BasePathType)Enum.Parse(typeof(BasePathType), EditorPrefs.GetString("AssetBundlesPathType", BasePathType.Streaming.ToString()));
+            //}
+            //else
+            //{
+            //    EditorPrefs.SetString("AssetBundlesPathType", basePathType.ToString());
+            //}
+#endif
+
+            switch (AssetBundleSettings.AssetBundlesBasePath)
+            {
+                case AssetBundleSettings.BasePathType.None:
+                    return string.Empty;
+                case AssetBundleSettings.BasePathType.StreamingAssets:
+                    return Application.streamingAssetsPath;
+                case AssetBundleSettings.BasePathType.Data:
+                    return Application.dataPath;
+                case AssetBundleSettings.BasePathType.PersistentData:
+                    return Application.persistentDataPath;
+                case AssetBundleSettings.BasePathType.Executable:
+                    if (Application.isEditor)
+                    {
+                        return Application.dataPath + "/../";
+                    }
+                    else if (Application.platform == RuntimePlatform.OSXPlayer)
+                    {
+                        return Application.dataPath + "/../../";
+                    }
+                    else if (Application.platform == RuntimePlatform.WindowsPlayer)
+                    {
+                        return Application.dataPath + "/../";
+                    }
+                    break;
+            }
+            return Application.persistentDataPath;
+        }
+
+
+        public static string GetAssetBundlesOutputPath()
+        {
+            if(AssetBundleSettings.AssetBundlesBasePath==AssetBundleSettings.BasePathType.None)
+            {
+                return AssetBundleSettings.AssetBundlesPath;
+            }
+            string path = Path.Combine(GetAssetBundlesBasePath(), AssetBundleSettings.AssetBundlesPath);
+            if (!path.EndsWith("/"))
+            {
+                path += "/";
+            }
+            return path;
+        }
+
+        public static string GetAssetBundlesOutputUrl()
+        {
+            string outputPath = GetAssetBundlesOutputPath();
+            if (outputPath.Contains("//"))
+            {
+                // URL
+                return outputPath;
+            }
+            else
+            {
+                return "file://" + outputPath;
+            }
+        }
 
         public static string GetPlatformName()
         {


### PR DESCRIPTION
Add a support for custom configuration.

Group utility methods in Utility class.

Instead of basing paths on the `streamingAssetsPath` use a custom
configuration that can be saved with the scene.